### PR TITLE
Error: Uncaught [TypeError: Cannot read property 'filter' of undefined]

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,10 @@ export class Flags extends Component {
     return (
       <FeatureFlags.Consumer>
         {(flags) => {
+          if (!Array.isArray(flags)) {
+            throw new Error('You should not use <Flags> outside a <FlagsProvider>');
+          }
+
           const matchingFlags = this.matchingFlags(flags);
           if (exactFlags) {
             return matchingFlags.length === authorizedFlags.length

--- a/src/test.js
+++ b/src/test.js
@@ -176,6 +176,13 @@ describe('Flags', () => {
       expect(result).toEqual(<h1>renderOn props</h1>);
     })
   })
+
+  describe('without context', () => {
+    it('without FlagsProvider or context', () => {
+      return expect(() => mount(<Flags authorizedFlags={[]} />))
+        .toThrow('You should not use <Flags> outside a <FlagsProvider>')
+    })
+  })
 })
 
 describe('FlagsProvider', () => {


### PR DESCRIPTION
fix: throws helpful error instead of trying to call `Array.prototype.filter` on `undefined`

instead of providing a sensible fallback value (e.g., empty array `[]`) i thought it would be more helpful to throw an error like you'd see if you try to use a `<Link>` without a `<Router>`:

```
    Error: Uncaught [Error: Invariant failed: You should not use <Link> outside a <Router>]
```